### PR TITLE
Correct event id FriendsChanged -> friendsChanged on Neos.js#L255

### DIFF
--- a/Neos.js
+++ b/Neos.js
@@ -252,7 +252,7 @@ class Neos extends EventEmitter {
 			this.emit("friendRequestCountChanged", count);
 		});
 		this.Events.on("friendsChanged", () => {
-			this.emit("FriendsChanged");
+			this.emit("friendsChanged");
 		});
 		this.Events.on("userUpdated", (user) => {
 			this.emit("userUpdated", user);


### PR DESCRIPTION
# Pull Request Template

## Description

Node events are case sensitive; friendsChanged is documented and used internally as friendsChanged but re-emitted as **F**riendsChanged. Fixes that.

no issue open for this issue

ed: also not my travis

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

-- will break existing uses of incorrect 'FriendsChanged' in user code targeting prior commits/versions

## How Has This Been Tested?

n/a

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
